### PR TITLE
Allow MIX_ENV to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ installed.
     mix run -e "Exdeploy.build(\"project_name\", \"/my/project/path\", user: \"the_user\", group: \"the_group\")"
 
 This will install hex and rebar, fetch deps, compile and make a release with
-`MIX_ENV=prod`. The executing user must have read/write access to
+`MIX_ENV=prod`. If you want to build for another environment, for instance `staging`, set `BUILD_ENV=staging`.
+The executing user must have read/write access to
 `/my/project/path`. After running, if `user` and/or `group` options are
 specified, the owner and group of the build folder will be changed to match.
 

--- a/lib/exdeploy/app.ex
+++ b/lib/exdeploy/app.ex
@@ -52,7 +52,8 @@ defmodule Exdeploy.App do
 
   def mix(app, cmd, env \\ [], opts \\ []) do
     args = String.split(cmd, " ")
-    env = [{"MIX_ENV", "prod"}] ++ env
+    build_env = System.get_env("BUILD_ENV") || "prod"
+    env = [{"MIX_ENV", build_env}] ++ env
     opts = [env: env, cd: app.path, stderr_to_stdout: true] ++ opts
     Logger.info inspect {env, app.path, "mix", cmd}
     {output, exit_status} = System.cmd("mix", args, opts)


### PR DESCRIPTION
This allows you to set the MIX_ENV when building the app. You can set it via BUILD_ENV variable. I am using this to build my app in `staging` env. 

`BUILD_ENV=staging mix run -e "Exdeploy.build(\"my_app\", \"/home/ubuntu/my_app\", user: \"ubuntu\", group: \"ubuntu\")"`
